### PR TITLE
Don't look for SFML if it's already found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,10 @@ option( SFML_STATIC_LIBRARIES   "Do you want to link SFML statically?"          
 
 # Find packages.
 find_package( OpenGL REQUIRED )
-find_package( SFML 2.5 REQUIRED COMPONENTS graphics window system )
+
+if( NOT TARGET sfml-graphics )
+    find_package( SFML 2.5 REQUIRED COMPONENTS graphics window system )
+endif()
 
 set( INCLUDE_PATH "${PROJECT_SOURCE_DIR}/include/" )
 set( SOURCE_PATH "${PROJECT_SOURCE_DIR}/src/" )


### PR DESCRIPTION
This modification allows to have sfml and sfgui as submodules in a github repository and have them built by your project's CMakeLists by doing 

```
add_subdirectory("submodules/SFML")
add_subdirectory("submodules/SFGUI")
```